### PR TITLE
Systemd configuration to autostart on boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,12 @@ The available device numbers can be found using `arecord -l`.
 ## Daemonization
 
 If you want this to be run on startup, copy the file "./system_configuration/fm_transmitter.service" to /lib/systemd/system/ 
+then, on the pi:
+```
+sudo systemctl enable fm_transmitter.service
+sudo systemctl start fm_transmitter.service
 
+```
 ## Law
 Please keep in mind that transmitting on certain frequencies without special 
 permissions may be illegal in your country.

--- a/README.md
+++ b/README.md
@@ -77,14 +77,20 @@ Should you want to edit the options passed to fm_transmitter, you can by editing
 
 #### Job Control
 ```systemctl start fm_transmitter``` - start process
+
 ```systemctl stop fm_transmitter``` - graceful stop process - this usually works
-```systemctl kill fm_transmitter`` - kill process
+
+```systemctl kill fm_transmitter``` - kill process
+
 ```sudo systemctl restart fm_transmitter``` - restart service manually ( it will restart by itself on process exit)
 
 #### Status
 ```systemctl``` - list all systemd services, you should see fm_transmitter in here
+
 ```systemctl | grep fm_transmitter``` - terser way of seeing if fm_transmitter is running
+
 ```systemctl status fm_transmitter``` - See detailed status for fm_transmitter
+
 ```sudo journalctl -u fm_transmitter``` - See ouput of fm_transmitter
 
 #### Development`

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ The available device numbers can be found using `arecord -l`.
   > resampling, so it may fail if the sampling rate (44.1kHz) is not hardware 
   > supported.
 
+## Daemonization
+
+If you want this to be run on startup, copy the file "./system_configuration/fm_transmitter.service" to /lib/systemd/system/ 
+
 ## Law
 Please keep in mind that transmitting on certain frequencies without special 
 permissions may be illegal in your country.
+

--- a/README.md
+++ b/README.md
@@ -60,13 +60,36 @@ The available device numbers can be found using `arecord -l`.
 
 ## Daemonization
 
-If you want this to be run on startup, copy the file "./system_configuration/fm_transmitter.service" to /lib/systemd/system/ 
+If you want this to be run on startup, copy one of the config files in system_configuration into /lib/systemd/system/fm_transmitter.service (no extension)
+There are two files in there, one will play starwars, the other stdout.
+ 
 then, on the pi:
 ```
 sudo systemctl enable fm_transmitter.service
 sudo systemctl start fm_transmitter.service
-
 ```
+
+The Pi should start to broadcast, and will restart when the program ends, and on boot. 
+
+Should you want to edit the options passed to fm_transmitter, you can by editing the ExecStart line in fm_transmitter.service
+
+### Useful Systemd Commands:
+
+#### Job Control
+```systemctl start fm_transmitter``` - start process
+```systemctl stop fm_transmitter``` - graceful stop process - this usually works
+```systemctl kill fm_transmitter`` - kill process
+```sudo systemctl restart fm_transmitter``` - restart service manually ( it will restart by itself on process exit)
+
+#### Status
+```systemctl``` - list all systemd services, you should see fm_transmitter in here
+```systemctl | grep fm_transmitter``` - terser way of seeing if fm_transmitter is running
+```systemctl status fm_transmitter``` - See detailed status for fm_transmitter
+```sudo journalctl -u fm_transmitter``` - See ouput of fm_transmitter
+
+#### Development`
+```sudo systemctl daemon-reload``` - reload config after editing (follow with systemctl restart)
+
 ## Law
 Please keep in mind that transmitting on certain frequencies without special 
 permissions may be illegal in your country.

--- a/system_configuration/fm_transmitter.service
+++ b/system_configuration/fm_transmitter.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=CDF FM Transmitter
+ 
+[Service]
+ExecStart=/home/pi/FM_transmitter/fm_transmitter
+StandardOutput=null
+ 
+[Install]
+WantedBy=multi-user.target
+Alias=fm_transmitter.service
+

--- a/system_configuration/fm_transmitter.service.__starwars__
+++ b/system_configuration/fm_transmitter.service.__starwars__
@@ -3,7 +3,6 @@ Description=CDF FM Transmitter
  
 [Service]
 ExecStart=/home/pi/FM_transmitter/fm_transmitter -f 89.1 -s 0.078 /home/pi/FM_transmitter/star_wars.wav 
-StandardOutput=null
 Restart=always
 RestartSec=3
  

--- a/system_configuration/fm_transmitter.service.__starwars__
+++ b/system_configuration/fm_transmitter.service.__starwars__
@@ -1,12 +1,13 @@
 [Unit]
 Description=CDF FM Transmitter
- 
+
 [Service]
-ExecStart=/home/pi/FM_transmitter/fm_transmitter -f 89.1 -s 0.078 /home/pi/FM_transmitter/star_wars.wav 
+ExecStart=/home/pi/FM_transmitter/fm_transmitter -f 89.1 -s 0.078 /home/pi/FM_transmitter/star_wars.wav
 Restart=always
 RestartSec=3
 KillSignal=SIGINT
- 
+TimeoutStopSec=10
+
 [Install]
 WantedBy=multi-user.target
 Alias=fm_transmitter.service

--- a/system_configuration/fm_transmitter.service.__starwars__
+++ b/system_configuration/fm_transmitter.service.__starwars__
@@ -1,0 +1,13 @@
+[Unit]
+Description=CDF FM Transmitter
+ 
+[Service]
+ExecStart=/home/pi/FM_transmitter/fm_transmitter -f 89.1 -s 0.078 /home/pi/FM_transmitter/star_wars.wav 
+StandardOutput=null
+Restart=always
+RestartSec=3
+ 
+[Install]
+WantedBy=multi-user.target
+Alias=fm_transmitter.service
+

--- a/system_configuration/fm_transmitter.service.__starwars__
+++ b/system_configuration/fm_transmitter.service.__starwars__
@@ -5,6 +5,7 @@ Description=CDF FM Transmitter
 ExecStart=/home/pi/FM_transmitter/fm_transmitter -f 89.1 -s 0.078 /home/pi/FM_transmitter/star_wars.wav 
 Restart=always
 RestartSec=3
+KillSignal=SIGINT
  
 [Install]
 WantedBy=multi-user.target

--- a/system_configuration/fm_transmitter.service.__stdout__
+++ b/system_configuration/fm_transmitter.service.__stdout__
@@ -2,8 +2,10 @@
 Description=CDF FM Transmitter
  
 [Service]
-ExecStart=/home/pi/FM_transmitter/fm_transmitter
+ExecStart=/home/pi/FM_transmitter/fm_transmitter -f 89.1 -s 0.078 - 
 StandardOutput=null
+Restart=always
+RestartSec=3
  
 [Install]
 WantedBy=multi-user.target

--- a/system_configuration/fm_transmitter.service.__stdout__
+++ b/system_configuration/fm_transmitter.service.__stdout__
@@ -5,7 +5,8 @@ Description=CDF FM Transmitter
 ExecStart=/home/pi/FM_transmitter/fm_transmitter -f 89.1 -s 0.078 - 
 Restart=always
 RestartSec=3
- 
+KillSignal=SIGINT
+
 [Install]
 WantedBy=multi-user.target
 Alias=fm_transmitter.service

--- a/system_configuration/fm_transmitter.service.__stdout__
+++ b/system_configuration/fm_transmitter.service.__stdout__
@@ -3,7 +3,6 @@ Description=CDF FM Transmitter
  
 [Service]
 ExecStart=/home/pi/FM_transmitter/fm_transmitter -f 89.1 -s 0.078 - 
-StandardOutput=null
 Restart=always
 RestartSec=3
  

--- a/system_configuration/fm_transmitter.service.__stdout__
+++ b/system_configuration/fm_transmitter.service.__stdout__
@@ -1,11 +1,12 @@
 [Unit]
 Description=CDF FM Transmitter
- 
+
 [Service]
-ExecStart=/home/pi/FM_transmitter/fm_transmitter -f 89.1 -s 0.078 - 
+ExecStart=/home/pi/FM_transmitter/fm_transmitter -f 89.1 -s 0.078 -
 Restart=always
 RestartSec=3
 KillSignal=SIGINT
+TimeoutStopSec=10
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I added documentation on how to configure the fm_transmitter to auto-start on boot, and on process failure.  This uses systemd, which is the powerful new init system for linux. 
There's a single file that should be moved to /lib/systemd/system. I have included instructions for how to do this to the README, as well as some useful commands for interacting with systemd. 

I envision we might want to alternate between usb auto and canned music, and unfortunately, I didn't find an easy way to change the command line options in the systemd script. There is some environmental variable schenanigans that we can do, or we could make two services, one for each option (```fm_transmit_live```, ```fm_transmit_canned``` ?)

We're also working on a preconfigured image for the pi, and we aim to have this demonization pre-installed. 

This addresses issue https://github.com/coup-de-foudre/FM_transmitter/issues/12

